### PR TITLE
Add RTL support to Wikipedia generator

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -68,6 +68,13 @@ class Generators(unittest.TestCase):
             self.assertTrue(img.size[1] == 32, "Shape is not right")
             i += 1
 
+    def test_generator_from_wikipedia_rtl(self):
+        generator = GeneratorFromWikipedia(
+            count=1, language="ar", rtl=True, fonts=["tests/font_ar.ttf"]
+        )
+        img, lbl = next(generator)
+        self.assertTrue(img.size[1] == 32 and isinstance(lbl, str))
+
     def test_generator_from_dict_stops(self):
         generator = GeneratorFromDict(count=1)
         next(generator)


### PR DESCRIPTION
## Summary
- add `rtl` parameter to `GeneratorFromWikipedia`
- reshape regenerated Wikipedia strings when RTL is enabled
- add regression test for RTL Wikipedia generation

## Testing
- `python tests.py` *(fails: requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0))*

------
https://chatgpt.com/codex/tasks/task_e_68909961e9bc83309dc91f8c0d163ce6