### PR TITLE
Add font glyph utilities and filter

### DIFF
--- a/requirements-hw.txt
+++ b/requirements-hw.txt
@@ -8,3 +8,4 @@ diffimg==0.2.3
 tensorflow>=1.13.1,<1.14
 matplotlib>=3.0.2
 seaborn>=0.9.0
+fonttools>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ diffimg==0.2.3
 arabic-reshaper==2.1.3
 python-bidi==0.4.2
 wikipedia>=1.4.0
+fonttools>=4.0.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+from trdg.utils import font_has_glyph, filter_fonts_for_text
+
+
+def test_font_has_glyph():
+    assert font_has_glyph("tests/font.ttf", "A")
+    assert not font_has_glyph("tests/font.ttf", "ش")
+
+
+def test_filter_fonts_for_text():
+    fonts = ["tests/font.ttf", "tests/font_ar.ttf"]
+    assert filter_fonts_for_text("A", fonts) == ["tests/font.ttf"]
+    assert filter_fonts_for_text("ش", fonts) == ["tests/font_ar.ttf"]
+    assert filter_fonts_for_text("Aش", fonts) == []

--- a/trdg/utils.py
+++ b/trdg/utils.py
@@ -7,6 +7,8 @@ import re
 import unicodedata
 from typing import List, Tuple
 
+from fontTools.ttLib import TTFont
+
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
@@ -147,3 +149,28 @@ def get_text_height(image_font: ImageFont, text: str) -> int:
     """
     left, top, right, bottom = image_font.getbbox(text)
     return bottom
+
+
+def font_has_glyph(font_path: str, char: str) -> bool:
+    """
+    Check whether a font contains a glyph for a given character.
+    """
+    try:
+        font = TTFont(font_path)
+        cmap = font.getBestCmap()
+        return ord(char) in cmap
+    except Exception:
+        return False
+    finally:
+        try:
+            font.close()
+        except Exception:
+            pass
+
+
+def filter_fonts_for_text(text: str, fonts: List[str]) -> List[str]:
+    """
+    Filter a list of fonts, returning those that support all characters in the text.
+    """
+    required_chars = set(text)
+    return [f for f in fonts if all(font_has_glyph(f, c) for c in required_chars)]


### PR DESCRIPTION
## Summary
- add `font_has_glyph` utility leveraging fontTools to verify glyph coverage
- add `filter_fonts_for_text` helper to filter fonts based on character support
- include tests and declare fontTools dependency

## Testing
- `PYTHONPATH=. pytest tests/test_utils.py`
- `PYTHONPATH=. pytest tests/test_utils.py tests.py` *(fails: requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0))*


------
https://chatgpt.com/codex/tasks/task_e_6890a7e914ac83309f8254c2b2bb96fa