### PR TITLE
Filter labels to rendered glyphs only

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -127,7 +127,7 @@ class DataGenerator(unittest.TestCase):
         self.assertTrue(len(strings) == 2 and len(strings[0].split(" ")) == 3)
 
     def test_multiline_text_generation(self):
-        single, _ = computer_text_generator.generate(
+        single, _, _ = computer_text_generator.generate(
             "TEST",
             "tests/font.ttf",
             "#010101",
@@ -138,7 +138,7 @@ class DataGenerator(unittest.TestCase):
             True,
             False,
         )
-        multi, _ = computer_text_generator.generate(
+        multi, _, _ = computer_text_generator.generate(
             "TEST\nTEST",
             "tests/font.ttf",
             "#010101",
@@ -150,6 +150,24 @@ class DataGenerator(unittest.TestCase):
             False,
         )
         self.assertTrue(multi.size[1] > single.size[1])
+
+    def test_filtered_label_matches_visible_text(self):
+        text = "AB汉C"
+        _, mask, label = computer_text_generator.generate(
+            text,
+            "tests/font.ttf",
+            "#010101",
+            32,
+            0,
+            1,
+            0,
+            True,
+            False,
+        )
+        from trdg.utils import mask_to_bboxes
+
+        self.assertEqual(label, "ABC")
+        self.assertEqual(len(mask_to_bboxes(mask)), len(label))
 
     def test_generate_data_with_format(self):
         FakeTextDataGenerator.generate(

--- a/trdg/computer_text_generator.py
+++ b/trdg/computer_text_generator.py
@@ -150,12 +150,15 @@ def _generate_horizontal_text(
     line_chars = []
     line_widths = []
     line_heights = []
+    rendered_lines = []
 
     for line in lines:
         chars_info = []
+        rendered_line = []
         for c in line:
             if c == " ":
                 chars_info.append((c, space_width, image_font))
+                rendered_line.append(c)
                 continue
 
             selected_font = _select_font_for_char(
@@ -178,6 +181,7 @@ def _generate_horizontal_text(
                 fallback_font,
             )
             chars_info.append((c, width, selected_font))
+            rendered_line.append(c)
 
         line_width = sum(w for _, w, _ in chars_info)
         if not word_split:
@@ -193,6 +197,7 @@ def _generate_horizontal_text(
         line_chars.append(chars_info)
         line_widths.append(line_width)
         line_heights.append(line_height)
+        rendered_lines.append("".join(rendered_line))
 
     text_width = max(line_widths) if line_widths else 0
     text_height = sum(line_heights)
@@ -257,11 +262,16 @@ def _generate_horizontal_text(
             x_offset += width
             char_index += 1
         y_offset += line_height
+    label = "\n".join(rendered_lines)
 
     if fit:
-        return txt_img.crop(txt_img.getbbox()), txt_mask.crop(txt_img.getbbox())
+        return (
+            txt_img.crop(txt_img.getbbox()),
+            txt_mask.crop(txt_img.getbbox()),
+            label,
+        )
     else:
-        return txt_img, txt_mask
+        return txt_img, txt_mask, label
 
 
 def _generate_vertical_text(
@@ -287,11 +297,13 @@ def _generate_vertical_text(
     space_height = int(get_text_height(image_font, " ") * space_width)
 
     chars_info = []
+    rendered_chars = []
     for c in text:
         if c == " ":
             height = space_height
             width = get_text_width(image_font, c)
             chars_info.append((c, width, height, image_font))
+            rendered_chars.append(c)
             continue
 
         selected_font = _select_font_for_char(
@@ -308,6 +320,7 @@ def _generate_vertical_text(
         width = get_text_width(selected_font, c)
         height = get_text_height(selected_font, c)
         chars_info.append((c, width, height, selected_font))
+        rendered_chars.append(c)
 
     text_width = max([w for _, w, _, _ in chars_info]) if chars_info else 0
     text_height = (
@@ -361,8 +374,13 @@ def _generate_vertical_text(
         )
         y_offset += height + character_spacing
         char_index += 1
+    label = "".join(rendered_chars)
 
     if fit:
-        return txt_img.crop(txt_img.getbbox()), txt_mask.crop(txt_img.getbbox())
+        return (
+            txt_img.crop(txt_img.getbbox()),
+            txt_mask.crop(txt_img.getbbox()),
+            label,
+        )
     else:
-        return txt_img, txt_mask
+        return txt_img, txt_mask, label

--- a/trdg/data_generator.py
+++ b/trdg/data_generator.py
@@ -68,8 +68,9 @@ class FakeTextDataGenerator(object):
             if orientation == 1:
                 raise ValueError("Vertical handwritten text is unavailable")
             image, mask = handwritten_text_generator.generate(text, text_color)
+            label = text
         else:
-            image, mask = computer_text_generator.generate(
+            image, mask, label = computer_text_generator.generate(
                 text,
                 font,
                 text_color,
@@ -82,6 +83,7 @@ class FakeTextDataGenerator(object):
                 stroke_width,
                 stroke_fill,
             )
+        text = label
         random_angle = rnd.randint(0 - skewing_angle, skewing_angle)
 
         rotated_img = image.rotate(


### PR DESCRIPTION
## Summary
- track rendered characters in horizontal/vertical text generation
- filter labels to rendered glyphs and propagate through data generator
- add test ensuring labels match rendered text when glyphs missing

## Testing
- `PYTHONPATH=. pytest tests.py::DataGenerator::test_filtered_label_matches_visible_text -q`
- `PYTHONPATH=. pytest tests.py` *(fails: DataGenerator::test_generate_data_with_hindi_text and others)*


------
https://chatgpt.com/codex/tasks/task_e_68973c8daa808330834e181d7d935b95