### PR TITLE
Propagate filtered labels from text generators

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -68,6 +68,39 @@ class Generators(unittest.TestCase):
             self.assertTrue(img.size[1] == 32, "Shape is not right")
             i += 1
 
+    def test_generators_filtered_labels(self):
+        text = "AB汉C"
+
+        gen_strings = GeneratorFromStrings([text], count=1, fonts=["tests/font.ttf"])
+        img, lbl = next(gen_strings)
+        self.assertEqual(lbl, "ABC")
+
+        gen_dict = GeneratorFromDict(count=1, fonts=["tests/font.ttf"])
+        gen_dict.generator.strings = [text]
+        img, lbl = next(gen_dict)
+        self.assertEqual(lbl, "ABC")
+
+        gen_random = GeneratorFromRandom(count=1, fonts=["tests/font.ttf"])
+        gen_random.generator.strings = [text]
+        img, lbl = next(gen_random)
+        self.assertEqual(lbl, "ABC")
+
+        from trdg.generators import from_wikipedia as wiki_gen
+
+        original_wiki = wiki_gen.create_strings_from_wikipedia
+
+        def mock_wiki(minimum_length, count, language):
+            return [text]
+
+        wiki_gen.create_strings_from_wikipedia = mock_wiki
+        try:
+            gen_wiki = GeneratorFromWikipedia(count=1, fonts=["tests/font.ttf"])
+            gen_wiki.generator.strings = [text]
+            img, lbl = next(gen_wiki)
+            self.assertEqual(lbl, "ABC")
+        finally:
+            wiki_gen.create_strings_from_wikipedia = original_wiki
+
     def test_generator_from_wikipedia_rtl(self):
         generator = GeneratorFromWikipedia(
             count=1, language="ar", rtl=True, fonts=["tests/font_ar.ttf"]

--- a/trdg/data_generator.py
+++ b/trdg/data_generator.py
@@ -288,5 +288,5 @@ class FakeTextDataGenerator(object):
                         )
         else:
             if output_mask == 1:
-                return final_image, final_mask
-            return final_image
+                return final_image, final_mask, label
+            return final_image, label

--- a/trdg/generators/from_strings.py
+++ b/trdg/generators/from_strings.py
@@ -100,43 +100,43 @@ class GeneratorFromStrings:
         if self.generated_count == self.count:
             raise StopIteration
         self.generated_count += 1
-        return (
-            FakeTextDataGenerator.generate(
-                self.generated_count,
-                self.strings[(self.generated_count - 1) % len(self.strings)],
-                self.fonts[(self.generated_count - 1) % len(self.fonts)],
-                None,
-                self.size,
-                None,
-                self.skewing_angle,
-                self.random_skew,
-                self.blur,
-                self.random_blur,
-                self.background_type,
-                self.distorsion_type,
-                self.distorsion_orientation,
-                self.is_handwritten,
-                0,
-                self.width,
-                self.alignment,
-                self.text_color,
-                self.orientation,
-                self.space_width,
-                self.character_spacing,
-                self.margins,
-                self.fit,
-                self.output_mask,
-                self.word_split,
-                self.image_dir,
-                self.stroke_width,
-                self.stroke_fill,
-                self.image_mode,
-                self.output_bboxes,
-            ),
-            self.orig_strings[(self.generated_count - 1) % len(self.orig_strings)]
-            if self.rtl
-            else self.strings[(self.generated_count - 1) % len(self.strings)],
+        result = FakeTextDataGenerator.generate(
+            self.generated_count,
+            self.strings[(self.generated_count - 1) % len(self.strings)],
+            self.fonts[(self.generated_count - 1) % len(self.fonts)],
+            None,
+            self.size,
+            None,
+            self.skewing_angle,
+            self.random_skew,
+            self.blur,
+            self.random_blur,
+            self.background_type,
+            self.distorsion_type,
+            self.distorsion_orientation,
+            self.is_handwritten,
+            0,
+            self.width,
+            self.alignment,
+            self.text_color,
+            self.orientation,
+            self.space_width,
+            self.character_spacing,
+            self.margins,
+            self.fit,
+            self.output_mask,
+            self.word_split,
+            self.image_dir,
+            self.stroke_width,
+            self.stroke_fill,
+            self.image_mode,
+            self.output_bboxes,
         )
+        if self.output_mask:
+            image, mask, label = result
+            return image, mask, label
+        image, label = result
+        return image, label
 
     def reshape_rtl(self, strings: list, rtl_shaper: ArabicReshaper):
         # reshape RTL characters before generating any image


### PR DESCRIPTION
## Summary
- Return filtered label from `FakeTextDataGenerator.generate`
- Expose propagated labels in `GeneratorFromStrings` and delegating generators
- Test that all generators return labels matching visible text when fonts lack glyphs

## Testing
- `pytest`
- `python -m unittest tests.Generators.test_generators_filtered_labels`


------
https://chatgpt.com/codex/tasks/task_e_689743b549d08330b75a4ed7319a9aed