### PR TITLE
Fix RTL label orientation

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -108,6 +108,14 @@ class Generators(unittest.TestCase):
         img, lbl = next(generator)
         self.assertTrue(img.size[1] == 32 and isinstance(lbl, str))
 
+    def test_generator_from_strings_rtl_label(self):
+        text = "مرحبا"
+        generator = GeneratorFromStrings(
+            [text], count=1, language="ar", rtl=True, fonts=["tests/font_ar.ttf"]
+        )
+        _, lbl = next(generator)
+        self.assertEqual(lbl, text)
+
     def test_generator_from_dict_stops(self):
         generator = GeneratorFromDict(count=1)
         next(generator)

--- a/trdg/generators/from_dict.py
+++ b/trdg/generators/from_dict.py
@@ -104,8 +104,16 @@ class GeneratorFromDict:
 
     def next(self):
         if self.generator.generated_count >= self.steps_until_regeneration:
-            self.generator.strings = create_strings_from_dict(
+            new_strings = create_strings_from_dict(
                 self.length, self.allow_variable, self.batch_size, self.dict
             )
+            if getattr(self.generator, "rtl", False):
+                # Keep original strings for labels and reshape copies for rendering
+                self.generator.orig_strings = new_strings
+                self.generator.strings = self.generator.reshape_rtl(
+                    new_strings, self.generator.rtl_shaper
+                )
+            else:
+                self.generator.strings = new_strings
             self.steps_until_regeneration += self.batch_size
         return self.generator.next()


### PR DESCRIPTION
## Summary
- Ensure labels for RTL strings remain in natural order
- Preserve original strings when regenerating dictionary-based text
- Add regression test covering RTL label generation

## Testing
- `pytest tests.py::Generators::test_generator_from_strings_rtl_label`
- `PYTHONPATH=. pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689769eb23d08330b7ba62d1ce900031