### PR TITLE
Add line wrapping option to generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,16 @@ from trdg.generators import (
 generator = GeneratorFromStrings(
     ['Test1', 'Test2', 'Test3'],
     blur=2,
-    random_blur=True
+    random_blur=True,
+    max_line_length=20,
 )
 
 for img, lbl in generator:
     # Do something with the pillow images here.
 ```
+
+All generators support the `max_line_length` parameter to automatically wrap
+long sentences without breaking words.
 
 You can see the full class definition here:
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,13 @@
+import os
+from trdg.generators.from_strings import GeneratorFromStrings
+
+
+def test_max_line_length_wraps_without_breaking_words():
+    test_font = os.path.join(os.path.dirname(__file__), 'font.ttf')
+    gen = GeneratorFromStrings(
+        ['This is a very long sentence'],
+        fonts=[test_font],
+        max_line_length=10,
+    )
+    img, label = next(gen)
+    assert label == 'This is a\nvery long\nsentence'

--- a/trdg/generators/from_dict.py
+++ b/trdg/generators/from_dict.py
@@ -45,6 +45,7 @@ class GeneratorFromDict:
         output_bboxes: int = 0,
         path: str = "",
         rtl: bool = False,
+        max_line_length: int = 0,
     ):
         self.count = count
         self.length = length
@@ -94,6 +95,7 @@ class GeneratorFromDict:
             image_mode,
             output_bboxes,
             rtl,
+            max_line_length=max_line_length,
         )
 
     def __iter__(self):
@@ -107,13 +109,6 @@ class GeneratorFromDict:
             new_strings = create_strings_from_dict(
                 self.length, self.allow_variable, self.batch_size, self.dict
             )
-            if getattr(self.generator, "rtl", False):
-                # Keep original strings for labels and reshape copies for rendering
-                self.generator.orig_strings = new_strings
-                self.generator.strings = self.generator.reshape_rtl(
-                    new_strings, self.generator.rtl_shaper
-                )
-            else:
-                self.generator.strings = new_strings
+            self.generator.set_strings(new_strings)
             self.steps_until_regeneration += self.batch_size
         return self.generator.next()

--- a/trdg/generators/from_random.py
+++ b/trdg/generators/from_random.py
@@ -46,6 +46,7 @@ class GeneratorFromRandom:
         stroke_fill: str = "#282828",
         image_mode: str = "RGB",
         output_bboxes: int = 0,
+        max_line_length: int = 0,
     ):
         self.generated_count = 0
         self.count = count
@@ -95,6 +96,7 @@ class GeneratorFromRandom:
             stroke_fill,
             image_mode,
             output_bboxes,
+            max_line_length=max_line_length,
         )
 
     def __iter__(self):
@@ -108,14 +110,16 @@ class GeneratorFromRandom:
 
     def next(self):
         if self.generator.generated_count >= self.steps_until_regeneration:
-            self.generator.strings = create_strings_randomly(
-                self.length,
-                self.allow_variable,
-                self.batch_size,
-                self.use_letters,
-                self.use_numbers,
-                self.use_symbols,
-                self.language,
+            self.generator.set_strings(
+                create_strings_randomly(
+                    self.length,
+                    self.allow_variable,
+                    self.batch_size,
+                    self.use_letters,
+                    self.use_numbers,
+                    self.use_symbols,
+                    self.language,
+                )
             )
             self.steps_until_regeneration += self.batch_size
         return self.generator.next()

--- a/trdg/generators/from_strings.py
+++ b/trdg/generators/from_strings.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 from typing import List, Tuple
 
 from trdg.data_generator import FakeTextDataGenerator
@@ -45,24 +46,12 @@ class GeneratorFromStrings:
         image_mode: str = "RGB",
         output_bboxes: int = 0,
         rtl: bool = False,
+        max_line_length: int = 0,
     ):
         self.count = count
-        self.strings = strings
-        # Keep a copy of the original strings so that labels remain in their
-        # natural order even when RTL reshaping is applied later on.
-        self.orig_strings = list(strings)
         self.fonts = fonts
         if len(fonts) == 0:
             self.fonts = load_fonts(language)
-        self.rtl = rtl
-        if self.rtl:
-            if language == "ckb":
-                ar_reshaper_config = {"delete_harakat": True, "language": "Kurdish"}
-            else:
-                ar_reshaper_config = {"delete_harakat": False}
-            self.rtl_shaper = ArabicReshaper(configuration=ar_reshaper_config)
-            # reshape the strings for rendering
-            self.strings = self.reshape_rtl(self.strings, self.rtl_shaper)
         self.language = language
         self.size = size
         self.skewing_angle = skewing_angle
@@ -89,6 +78,18 @@ class GeneratorFromStrings:
         self.stroke_width = stroke_width
         self.stroke_fill = stroke_fill
         self.image_mode = image_mode
+        self.max_line_length = max_line_length
+        self.rtl = rtl
+        if self.rtl:
+            if language == "ckb":
+                ar_reshaper_config = {"delete_harakat": True, "language": "Kurdish"}
+            else:
+                ar_reshaper_config = {"delete_harakat": False}
+            self.rtl_shaper = ArabicReshaper(configuration=ar_reshaper_config)
+        else:
+            self.rtl_shaper = None
+
+        self.set_strings(strings)
 
     def __iter__(self):
         return self
@@ -143,11 +144,38 @@ class GeneratorFromStrings:
 
         # Use original, unreshaped strings for labels when generating RTL text
         label = self.orig_strings[idx] if self.rtl else _label
-        label = "".join(c for c in label if c == " " or font_has_glyph(font, c))
+        label = "".join(
+            c for c in label if c in [" ", "\n"] or font_has_glyph(font, c)
+        )
 
         if self.output_mask:
             return image, mask, label
         return image, label
+
+    def set_strings(self, strings: List[str]):
+        wrapped = [self._wrap_text(s) for s in strings]
+        # Keep a copy of the original strings so that labels remain in their
+        # natural order even when RTL reshaping is applied later on.
+        self.orig_strings = list(wrapped)
+        if self.rtl:
+            self.strings = self.reshape_rtl(wrapped, self.rtl_shaper)
+        else:
+            self.strings = wrapped
+
+    def _wrap_text(self, text: str) -> str:
+        if self.max_line_length and self.max_line_length > 0:
+            lines = []
+            for line in text.split("\n"):
+                lines.extend(
+                    textwrap.wrap(
+                        line,
+                        width=self.max_line_length,
+                        break_long_words=False,
+                        break_on_hyphens=False,
+                    )
+                )
+            return "\n".join(lines)
+        return text
 
     def reshape_rtl(self, strings: list, rtl_shaper: ArabicReshaper):
         # reshape RTL characters before generating any image

--- a/trdg/generators/from_wikipedia.py
+++ b/trdg/generators/from_wikipedia.py
@@ -43,6 +43,7 @@ class GeneratorFromWikipedia:
         image_mode: str = "RGB",
         output_bboxes: int = 0,
         rtl: bool = False,
+        max_line_length: int = 0,
     ):
         self.generated_count = 0
         self.count = count
@@ -84,6 +85,7 @@ class GeneratorFromWikipedia:
             image_mode,
             output_bboxes,
             rtl,
+            max_line_length=max_line_length,
         )
 
     def __iter__(self):
@@ -100,12 +102,6 @@ class GeneratorFromWikipedia:
             new_strings = create_strings_from_wikipedia(
                 self.minimum_length, self.batch_size, self.language
             )
-            if self.generator.rtl:
-                self.generator.orig_strings = new_strings
-                self.generator.strings = self.generator.reshape_rtl(
-                    new_strings, self.generator.rtl_shaper
-                )
-            else:
-                self.generator.strings = new_strings
+            self.generator.set_strings(new_strings)
             self.steps_until_regeneration += self.batch_size
         return self.generator.next()


### PR DESCRIPTION
## Summary
- add `max_line_length` parameter to random, string, dictionary, and Wikipedia generators
- wrap long text without breaking words and keep newlines in labels
- document option and test wrapping behaviour

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689892a54ef08330b1eea1cfcc6bfda2