### PR TITLE
Optimize Wikipedia generator batch fetching

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -68,6 +68,30 @@ class Generators(unittest.TestCase):
             self.assertTrue(img.size[1] == 32, "Shape is not right")
             i += 1
 
+    def test_generator_from_wikipedia_uses_batch(self):
+        """Ensure that sentences are fetched in batches instead of per sample."""
+
+        from trdg.generators import from_wikipedia as wiki_gen
+
+        call_count = 0
+
+        def mock_wiki(minimum_length, count, language):
+            nonlocal call_count
+            call_count += 1
+            return ["TEST"] * count
+
+        original_wiki = wiki_gen.create_strings_from_wikipedia
+        wiki_gen.create_strings_from_wikipedia = mock_wiki
+        try:
+            generator = GeneratorFromWikipedia(fonts=["tests/font.ttf"])
+            for _ in range(100):
+                next(generator)
+            # ``create_strings_from_wikipedia`` should only be called once for
+            # the entire batch of 100 samples.
+            self.assertEqual(call_count, 1)
+        finally:
+            wiki_gen.create_strings_from_wikipedia = original_wiki
+
     def test_generators_filtered_labels(self):
         text = "AB汉C"
 

--- a/trdg/generators/from_wikipedia.py
+++ b/trdg/generators/from_wikipedia.py
@@ -51,7 +51,13 @@ class GeneratorFromWikipedia:
         self.language = language
         self.rtl = rtl
 
-        self.batch_size = min(max(count, 1), 1000)
+        # If no count is specified (negative values), fall back to a generous
+        # batch size so that we don't fetch new Wikipedia sentences on every
+        # call. Previously ``count`` defaulted to ``-1`` which resulted in a
+        # batch size of ``1``. That meant ``create_strings_from_wikipedia`` was
+        # triggered for every generated sample, causing a network request to
+        # Wikipedia each time and drastically slowing down the generator.
+        self.batch_size = min(count, 1000) if count > 0 else 1000
         self.steps_until_regeneration = self.batch_size
         self.generator = GeneratorFromStrings(
             create_strings_from_wikipedia(


### PR DESCRIPTION
## Summary
- Avoid fetching sentences from Wikipedia for every sample by using a default batch size
- Add unit test to ensure batch fetching behavior

## Testing
- `python -m unittest tests.Generators.test_generator_from_wikipedia_uses_batch`
- `python tests.py` *(fails: FileNotFoundError: 'fonts/void/')*

------
https://chatgpt.com/codex/tasks/task_e_6898b8dd1ab48330bed18601562f35e1