### PR TITLE
Stop ignoring font files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-*.otf
-*.ttf
-
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary
- remove `.otf` and `.ttf` patterns from `.gitignore` so font files can be tracked

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'trdg')*


------
https://chatgpt.com/codex/tasks/task_e_689b7e314ec883308576d3a92601c5f2