### PR TITLE
Align RTL text to left

### DIFF
--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -12,7 +12,7 @@ def test_max_line_length_wraps_without_breaking_words():
     img, label = next(gen)
     assert label == 'This is a\nvery long\nsentence'
 
-def test_rtl_text_is_right_aligned():
+def test_rtl_text_is_left_aligned():
     test_font = os.path.join(os.path.dirname(__file__), 'font_ar.ttf')
     gen = GeneratorFromStrings(
         ['مرحبا'],
@@ -24,7 +24,7 @@ def test_rtl_text_is_right_aligned():
     )
     img, _ = next(gen)
     bbox = ImageOps.invert(img.convert('L')).getbbox()
-    # Right edge should be within 5px of image right
-    assert img.width - bbox[2] <= 5
-    # Left edge should have some margin (>5px)
-    assert bbox[0] > 5
+    # Left edge should be within 5px of image left
+    assert bbox[0] <= 5
+    # Right edge should have some margin (>5px)
+    assert img.width - bbox[2] > 5

--- a/trdg/generators/from_strings.py
+++ b/trdg/generators/from_strings.py
@@ -62,7 +62,10 @@ class GeneratorFromStrings:
         self.is_handwritten = is_handwritten
         self.width = width
         self.rtl = rtl
-        self.alignment = 2 if self.rtl and alignment == 1 else alignment
+        # When generating right-to-left text, default to left alignment
+        # so the rendered text starts near the image's left edge unless a
+        # different alignment is explicitly requested.
+        self.alignment = 0 if self.rtl and alignment == 1 else alignment
         self.text_color = text_color
         self.orientation = orientation
         self.space_width = space_width


### PR DESCRIPTION
## Summary
- default to left alignment for right-to-left text generation
- adjust unit test to verify RTL output is left aligned

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cd79acb208330964b9c4ab53c0d07