### PR TITLE
Fix right alignment for multiline text

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -192,6 +192,26 @@ class DataGenerator(unittest.TestCase):
         )
         self.assertTrue(multi.size[1] > single.size[1])
 
+    def test_multiline_right_alignment(self):
+        _, mask, _ = computer_text_generator.generate(
+            "AB\nC",
+            "tests/font.ttf",
+            "#010101",
+            32,
+            0,
+            1,
+            0,
+            True,
+            False,
+            alignment=2,
+        )
+        from trdg.utils import mask_to_bboxes
+
+        bboxes = mask_to_bboxes(mask)
+        right_edge_line1 = max(bboxes[0][2], bboxes[1][2])
+        right_edge_line2 = bboxes[2][2]
+        self.assertTrue(abs(right_edge_line1 - right_edge_line2) <= 1)
+
     def test_filtered_label_matches_visible_text(self):
         text = "AB汉C"
         _, mask, label = computer_text_generator.generate(

--- a/trdg/computer_text_generator.py
+++ b/trdg/computer_text_generator.py
@@ -59,6 +59,7 @@ def generate(
     stroke_fill: str = "#282828",
     missing_glyph_strategy: str = "fallback",
     fallback_font: Optional[str] = None,
+    alignment: int = 0,
 ) -> Tuple:
     if orientation == 0:
         return _generate_horizontal_text(
@@ -74,6 +75,7 @@ def generate(
             stroke_fill,
             missing_glyph_strategy,
             fallback_font,
+            alignment,
         )
     elif orientation == 1:
         return _generate_vertical_text(
@@ -88,6 +90,7 @@ def generate(
             stroke_fill,
             missing_glyph_strategy,
             fallback_font,
+            alignment,
         )
     else:
         raise ValueError("Unknown orientation " + str(orientation))
@@ -135,6 +138,7 @@ def _generate_horizontal_text(
     stroke_fill: str = "#282828",
     missing_glyph_strategy: str = "fallback",
     fallback_font: Optional[str] = None,
+    alignment: int = 0,
 ) -> Tuple:
     image_font = ImageFont.truetype(font=font, size=font_size)
     fallback_image_font = (
@@ -229,8 +233,13 @@ def _generate_horizontal_text(
 
     char_index = 0
     y_offset = 0
-    for chars_info, line_height in zip(line_chars, line_heights):
-        x_offset = 0
+    for chars_info, line_height, line_width in zip(line_chars, line_heights, line_widths):
+        if alignment == 1:
+            x_offset = (text_width - line_width) // 2
+        elif alignment == 2:
+            x_offset = text_width - line_width
+        else:
+            x_offset = 0
         for i, (ch, width, fnt) in enumerate(chars_info):
             txt_img_draw.text(
                 (
@@ -286,6 +295,7 @@ def _generate_vertical_text(
     stroke_fill: str = "#282828",
     missing_glyph_strategy: str = "fallback",
     fallback_font: Optional[str] = None,
+    alignment: int = 0,
 ) -> Tuple:
     image_font = ImageFont.truetype(font=font, size=font_size)
     fallback_image_font = (

--- a/trdg/data_generator.py
+++ b/trdg/data_generator.py
@@ -82,6 +82,7 @@ class FakeTextDataGenerator(object):
                 word_split,
                 stroke_width,
                 stroke_fill,
+                alignment=alignment,
             )
         text = label
         random_angle = rnd.randint(0 - skewing_angle, skewing_angle)


### PR DESCRIPTION
## Summary
- allow text generator to align each line based on an `alignment` flag
- pass alignment through the data generator
- add test covering multiline right alignment

## Testing
- `PYTHONPATH=. pytest`
- `pytest tests.py::DataGenerator::test_multiline_right_alignment -q`
- `python tests.py` *(fails: JSONDecodeError from Wikipedia requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f42f60ec83309d3cddb23865fe54